### PR TITLE
Remove reviewers from Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,15 +5,11 @@ updates:
   schedule:
     interval: monthly
     timezone: Europe/Copenhagen
-  reviewers:
-  - arnested
 - package-ecosystem: composer
   directory: /
   schedule:
     interval: monthly
     timezone: Europe/Copenhagen
-  reviewers:
-  - arnested
   allow:
   - dependency-type: direct
   - dependency-type: indirect


### PR DESCRIPTION
See https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/
